### PR TITLE
Use binary releases and smaller Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,15 @@
-FROM ubuntu:latest
+FROM frolvlad/alpine-glibc:latest
 
-ENV TZ=America/Los_Angeles
-ENV GBDK2020_VERSION v4.0
-ENV SDCC_COMMIT 11929
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-RUN apt-get update && apt-get install -y git curl subversion build-essential flex bison libboost-dev \
-    texinfo zip netcat gawk python2.7 libz-dev \
-    && apt-get autoclean
-ENV SDCCDIR=/usr/local
+# GBDK-2020 version based on GitHub releases
+ENV GBDK2020_VERSION 4.0.2
 
-RUN mkdir /sdcc -p \
-    && cd /sdcc \
-    && svn checkout svn://svn.code.sf.net/p/sdcc/code/trunk/sdcc@${SDCC_COMMIT} \
-    && cd sdcc \
-    && ./configure --disable-pic14-port --disable-pic16-port \
-    && make && make install \
-    && cd / \
-    && rm -Rf /sdcc /tmp/*
+# install wget, make and libstdc++
+RUN apk add --no-cache wget make libstdc++
 
-WORKDIR /tmp
-RUN git clone --branch $GBDK2020_VERSION https://github.com/Zal0/gbdk-2020.git
-RUN cd /tmp/gbdk-2020 && make
-RUN cp -r /tmp/gbdk-2020/build/gbdk /opt
+RUN wget https://github.com/Zal0/gbdk-2020/releases/download/${GBDK2020_VERSION}/gbdk-linux64.tar.gz
+RUN tar -xf gbdk-linux64.tar.gz
+RUN rm gbdk-linux64.tar.gz
+RUN cp -r gbdk/ /opt
 ENV PATH="/opt/gbdk/bin:${PATH}"
-WORKDIR /opt
-RUN mkdir snake
+WORKDIR /opt/snakes
+

--- a/README.md
+++ b/README.md
@@ -23,23 +23,18 @@ $ cd snakes
 Build my dockerfile to make [GBDK-2020](https://github.com/Zal0/gbdk-2020.git) (couldn't make it work from the releases 😜) and get all the dev environment for free
 
 ```sh
-$ docker build --pull --rm -f "Dockerfile" -t snake:latest "."
+$ docker image build --pull --rm -f "Dockerfile" -t snake:latest "."
 ```
 
-Create a container to get everything in one place (Code and GBDK) and attach to it
+Build project with Docker:
 
 ```sh
-# I have no idea what I'm doing.
-$ SNAKE_DEV_ID=$(docker run -dit -P --name snake-dev -v $(pwd):/opt/snake snake:latest)
-$ docker attach $SNAKE_DEV_ID
-```
-
-_Note, for subsequent runs you only need to do_: `docker start snake-dev --interactive`
-
-Make it
-
-```sh
-cd snakes && make
+docker container run --rm -it -P \                                                                                                                                                   ⇣0 B/s ⇡0 B/s 192.168.1.150    95.169.225.75   ─╯
+--name snake-dev \
+--user `id -u`:`id -g` \
+-v $(pwd):/opt/snakes \
+snake:latest \
+make
 ```
 
 Making will generate a ROM `bin/main.gb` that you can use to run Snakes.
@@ -47,3 +42,4 @@ Making will generate a ROM `bin/main.gb` that you can use to run Snakes.
 # Contribuiting
 
 This is one of my COVID-19 projects, I appreciate your input regarding Docker stuff and C development tips, but I won't be accepting PRs that actually add to the game.
+


### PR DESCRIPTION
Hello!

I love ❤️ your snake game for many reasons:
- It is simple enough to start learning GB development using GBDK
- It is far more complex than simple Hello World project
- Uses [GBDK-2020](https://github.com/Zal0/gbdk-2020/)
- Uses Docker

So I decided to add my contribution 😄. These are the changes I decided to apply:
- Use [alpine-glibc](https://hub.docker.com/r/frolvlad/alpine-glibc/) Docker image because
  - It reduces final image size from >300 MB (Ubuntu based) to ~40 MB
  - It uses [glibc](https://www.gnu.org/software/libc/) instead of [musl-libc](https://www.musl-libc.org/) of [official Alpine image](https://hub.docker.com/_/alpine/)
- Use of binary releases of GBDK-2020
  - Instead of compiling it from sources, selecting release from GitHub GBDK-2020 official repo
  - Avoid compiling [SDCC](https://sourceforge.net/projects/sdcc/) from source
- Simplify build process using the Docker image and a single command invoking make inside it

Hope you like the changes! Any comment would be appreciated a lot.